### PR TITLE
C++11 and cupla target linking in cmake

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -18,18 +18,12 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# same dependency as ALPAKA_ADD_EXECUTABLE
-cmake_minimum_required(VERSION 3.3.0)
-
-
 macro(CUPLA_ADD_EXECUTABLE BinaryName)
-
-    include_directories(${cupla_INCLUDE_DIRS})
-    add_definitions(${cupla_DEFINITIONS})
 
     alpaka_add_executable(
         ${BinaryName}
         ${ARGN}
         ${cupla_SOURCE_FILES}
-    )
+        )
+    target_link_libraries(${BinaryName} PUBLIC cupla)
 endmacro()

--- a/cuplaConfig.cmake
+++ b/cuplaConfig.cmake
@@ -122,17 +122,17 @@ if(${cupla_ALPAKA_PROVIDER} STREQUAL "intern")
         execute_process (COMMAND git submodule update WORKING_DIRECTORY ${_cupla_ROOT_DIR})
     endif()
 
-    find_package(alpaka 
+    find_package(alpaka
         PATHS "${_cupla_ROOT_DIR}/alpaka"
-        NO_DEFAULT_PATH 
-        NO_CMAKE_ENVIRONMENT_PATH 
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
         NO_CMAKE_PATH
         NO_SYSTEM_ENVIRONMENT_PATH
         NO_CMAKE_PACKAGE_REGISTRY
         NO_CMAKE_BUILDS_PATH
         NO_CMAKE_SYSTEM_PATH
         NO_CMAKE_SYSTEM_PACKAGE_REGISTRY
-        NO_CMAKE_FIND_ROOT_PATH   
+        NO_CMAKE_FIND_ROOT_PATH
     )
 else()
     find_package(alpaka HINTS $ENV{ALPAKA_ROOT})
@@ -142,6 +142,7 @@ if(NOT alpaka_FOUND)
     message(WARNING "Required cupla dependency alpaka could not be found!")
         set(_cupla_FOUND FALSE)
 else()
+    # TODO: use imported targets instead of chain of variables
     list(APPEND _cupla_COMPILE_OPTIONS_PUBLIC ${alpaka_COMPILE_OPTIONS})
     list(APPEND _cupla_COMPILE_DEFINITIONS_PUBLIC ${alpaka_COMPILE_DEFINITIONS})
     list(APPEND _cupla_INCLUDE_DIRECTORIES_PUBLIC ${alpaka_INCLUDE_DIRS})
@@ -180,7 +181,7 @@ endif()
 # cupla.
 ################################################################################
 
-OPTION(CUPLA_STREAM_ASYNC_ENABLE "Enable asynchron streams" ON)
+option(CUPLA_STREAM_ASYNC_ENABLE "Enable asynchronous streams" ON)
 if(CUPLA_STREAM_ASYNC_ENABLE)
     list(APPEND _cupla_COMPILE_DEFINITIONS_PUBLIC "CUPLA_STREAM_ASYNC_ENABLED=1")
 else()
@@ -233,12 +234,12 @@ if(NOT TARGET cupla)
     message(STATUS "_cupla_COMPILE_OPTIONS_PUBLIC: ${_cupla_COMPILE_OPTIONS_PUBLIC}")
     list(
         LENGTH
-        _cupla_COMPILE_optionS_PUBLIC
-        _cupla_COMPILE_optionS_PUBLIC_LENGTH)
-    if("${_cupla_COMPILE_optionS_PUBLIC_LENGTH}")
-        TARGET_COMPILE_optionS(
+        _cupla_COMPILE_OPTIONS_PUBLIC
+        _cupla_COMPILE_OPTIONS_PUBLIC_LENGTH)
+    if("${_cupla_COMPILE_OPTIONS_PUBLIC_LENGTH}")
+        TARGET_COMPILE_OPTIONS(
             "cupla"
-            PUBLIC ${_cupla_COMPILE_optionS_PUBLIC})
+            PUBLIC ${_cupla_COMPILE_OPTIONS_PUBLIC})
     endif()
 
     # Compile definitions.
@@ -356,8 +357,8 @@ endif()
 
 # Handles the REQUIRED, QUIET and version-related arguments for find_package.
 # NOTE: We do not check for cupla_LIBRARIES and cupla_DEFINITIONS because they can be empty.
-INCLUDE(FindPackageHandleStandardArgs)
-find_package_HANDLE_STANDARD_ARGS(
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
     "cupla"
     FOUND_VAR cupla_FOUND
     REQUIRED_VARS cupla_INCLUDE_DIR

--- a/cuplaConfig.cmake
+++ b/cuplaConfig.cmake
@@ -219,6 +219,16 @@ if(NOT TARGET cupla)
     # Even if there are no sources CMAKE has to know the language.
     set_target_properties("cupla" PROPERTIES LINKER_LANGUAGE CXX)
 
+    # properties
+    target_compile_features("cupla"
+        PUBLIC cxx_std_11
+        )
+    set_target_properties("cupla" PROPERTIES
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+        )
+
+
     # Compile options.
     message(STATUS "_cupla_COMPILE_OPTIONS_PUBLIC: ${_cupla_COMPILE_OPTIONS_PUBLIC}")
     list(

--- a/example/CUDASamples/asyncAPI/CMakeLists.txt
+++ b/example/CUDASamples/asyncAPI/CMakeLists.txt
@@ -18,24 +18,19 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ################################################################################
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11.0)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ################################################################################
 # Project.
 ################################################################################
 
-SET(_INCLUDE_DIR "../common/")
-SET(_SUFFIXED_INCLUDE_DIR "../common/")
-SET(_SOURCE_DIR "src/")
-
-PROJECT("asyncAPI")
+project(asyncAPI)
 
 ################################################################################
 # CMake policies
@@ -52,34 +47,22 @@ endif()
 # Find cupla
 ################################################################################
 
-SET(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
+set(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
 
-LIST(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
-FIND_PACKAGE("cupla" REQUIRED)
+list(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
+find_package(cupla REQUIRED)
 
 
 ################################################################################
 # Add library.
 ################################################################################
 
-# Add all the include files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "hpp" _FILES_HEADER)
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "h" _FILES_HEADER)
+set(_SOURCE_DIR "src/")
 
 # Add all the source files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_CXX)
 
-set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
-
-include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
-
-
 # Always add all files to the target executable build call to add them to the build project.
-cupla_add_executable(
-    "asyncAPI"
-    ${_FILES_SOURCE_CXX})
+cupla_add_executable(${PROJECT_NAME} ${_FILES_SOURCE_CXX})
 
-# Set the link libraries for this library (adds libs, include directories, defines and compile options).
-target_link_libraries(
-    "asyncAPI"
-    PUBLIC ${cupla_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE "../common/")

--- a/example/CUDASamples/asyncAPI_tuned/CMakeLists.txt
+++ b/example/CUDASamples/asyncAPI_tuned/CMakeLists.txt
@@ -23,19 +23,15 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11.0)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ################################################################################
 # Project.
 ################################################################################
 
-SET(_INCLUDE_DIR "../common/")
-SET(_SUFFIXED_INCLUDE_DIR "../common/")
-SET(_SOURCE_DIR "src/")
-
-PROJECT("asyncAPI_tuned")
+project(asyncAPI_tuned)
 
 ################################################################################
 # CMake policies
@@ -52,33 +48,22 @@ endif()
 # Find cupla
 ################################################################################
 
-SET(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
+set(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
 
-LIST(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
-FIND_PACKAGE("cupla" REQUIRED)
+list(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
+find_package(cupla REQUIRED)
 
 
 ################################################################################
 # Add library.
 ################################################################################
 
-# Add all the include files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "hpp" _FILES_HEADER)
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "h" _FILES_HEADER)
+set(_SOURCE_DIR "src/")
 
 # Add all the source files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_CXX)
 
-set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
-
-include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
-
 # Always add all files to the target executable build call to add them to the build project.
-cupla_add_executable(
-    "asyncAPI_tuned"
-    ${_FILES_SOURCE_CXX})
+cupla_add_executable(${PROJECT_NAME} ${_FILES_SOURCE_CXX})
 
-# Set the link libraries for this library (adds libs, include directories, defines and compile options).
-target_link_libraries(
-    "asyncAPI_tuned"
-    PUBLIC ${cupla_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE "../common/")

--- a/example/CUDASamples/matrixMul/CMakeLists.txt
+++ b/example/CUDASamples/matrixMul/CMakeLists.txt
@@ -23,19 +23,15 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11.0)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ################################################################################
 # Project.
 ################################################################################
 
-SET(_INCLUDE_DIR "../common/")
-SET(_SUFFIXED_INCLUDE_DIR "../common/")
-SET(_SOURCE_DIR "src/")
-
-PROJECT("matrixMul")
+project(matrixMul)
 
 ################################################################################
 # CMake policies
@@ -52,33 +48,22 @@ endif()
 # Find cupla
 ################################################################################
 
-SET(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
+set(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
 
-LIST(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
-FIND_PACKAGE("cupla" REQUIRED)
+list(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
+find_package(cupla REQUIRED)
 
 
 ################################################################################
 # Add library.
 ################################################################################
 
-# Add all the include files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "hpp" _FILES_HEADER)
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "h" _FILES_HEADER)
+set(_SOURCE_DIR "src/")
 
 # Add all the source files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_CXX)
 
-set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
-
-include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
-
 # Always add all files to the target executable build call to add them to the build project.
-cupla_add_executable(
-    "matrixMul"
-    ${_FILES_SOURCE_CXX})
+cupla_add_executable(${PROJECT_NAME} ${_FILES_SOURCE_CXX})
 
-# Set the link libraries for this library (adds libs, include directories, defines and compile options).
-target_link_libraries(
-    "matrixMul"
-    PUBLIC ${cupla_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE "../common/")

--- a/example/CUDASamples/vectorAdd/CMakeLists.txt
+++ b/example/CUDASamples/vectorAdd/CMakeLists.txt
@@ -18,24 +18,19 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 ################################################################################
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11.0)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ################################################################################
 # Project.
 ################################################################################
 
-SET(_INCLUDE_DIR "../common/")
-SET(_SUFFIXED_INCLUDE_DIR "../common/")
-SET(_SOURCE_DIR "src/")
-
-PROJECT("vecorAdd")
+project(vectorAdd)
 
 ################################################################################
 # CMake policies
@@ -52,33 +47,22 @@ endif()
 # Find cupla
 ################################################################################
 
-SET(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
+set(cupla_ROOT "$ENV{CUPLA_ROOT}" CACHE STRING  "The location of the cupla library")
 
-LIST(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
-FIND_PACKAGE("cupla" REQUIRED)
+list(APPEND CMAKE_MODULE_PATH "${cupla_ROOT}")
+find_package(cupla REQUIRED)
 
 
 ################################################################################
 # Add library.
 ################################################################################
 
-# Add all the include files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "hpp" _FILES_HEADER)
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "h" _FILES_HEADER)
+set(_SOURCE_DIR "src/")
 
 # Add all the source files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_CXX)
 
-set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
-
-include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
-
 # Always add all files to the target executable build call to add them to the build project.
-cupla_add_executable(
-    "vectorAdd"
-    ${_FILES_SOURCE_CXX})
+cupla_add_executable(${PROJECT_NAME} ${_FILES_SOURCE_CXX})
 
-# Set the link libraries for this library (adds libs, include directories, defines and compile options).
-target_link_libraries(
-    "vectorAdd"
-    PUBLIC ${cupla_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE "../common/")


### PR DESCRIPTION
it seems there is a lot of redundancy in the cmake files, i.e., there are many internal variables and there are targets that do almost the same job with less code as they propagate the needed flags anyway. 

I would like to start to refactor in favor of using targets. This PR is just a start for that, also to initiate some feedback on potential issues.

This PR contains:
- C++11 feature on cupla target
- already includes the cupla link inside the `CUPLA_ADD_EXECUTABLE`
- examples rely on implicit cupla target linking, so you just have:
```cmake
cupla_add_executable(${PROJECT_NAME} ${_FILES_SOURCE_CXX})
target_include_directories(${PROJECT_NAME} PRIVATE "../common/")
```

Questions for next step:
- do you agree with these changes and this approach:
- I would like to modernize things in a separate PR, because I need this one only for #103 (and I also want to change the license before refactoring)
- may I use `macro()` instead of `function()` for `CUPLA_ADD_EXECUTABLE`? I do not see a need to create a separate scope for that (got issues with HIP and (un)scoped variables)
- I would like to bump the version from 0.1.1 to 0.1.2 in this PR

Edit: the refactoring of cmake files is not that important, that is also why it is kind of postponed to a separate PR