### PR TITLE
on device math functions

### DIFF
--- a/example/CUDASamples/blackScholes/src/BlackScholes_kernel.cuh
+++ b/example/CUDASamples/blackScholes/src/BlackScholes_kernel.cuh
@@ -13,7 +13,7 @@
 
 #include <cuda_to_cupla.hpp>
 #include <stdio.h>
-#ifndef __CUDACC__
+#if !(BOOST_LANG_CUDA || BOOST_LANG_HIP)
 struct float2{
     float x;
     float y;
@@ -39,8 +39,8 @@ float cndGPU(T_Acc const & acc, float d)
     const float RSQRT2PI = 0.39894228040143267793994605993438f;
 
     float
-    K = __fdividef(1.0f, (1.0f + 0.2316419f * fabsf(d)));
-    float cnd = RSQRT2PI * __expf(- 0.5f * d * d) *
+    K = __fdividef(1.0f, (1.0f + 0.2316419f * cupla::abs(d)));
+    float cnd = RSQRT2PI * cupla::exp(- 0.5f * d * d) *
           (K * (A1 + K * (A2 + K * (A3 + K * (A4 + K * A5)))));
     if (d > 0)
         cnd = 1.0f - cnd;
@@ -66,8 +66,8 @@ ALPAKA_FN_ACC void BlackScholesBodyGPU(
 {
     float sqrtT, expRT;
     float d1, d2, CNDD1, CNDD2;
-    sqrtT = sqrtf(T); /// __fdividef(1.0F, rsqrtf(T));
-    d1 = __fdividef(__logf(S / X) + (R + 0.5f * V * V) * T, V * sqrtT);
+    sqrtT = cupla::sqrt(T); /// __fdividef(1.0F, rsqrtf(T));
+    d1 = __fdividef(cupla::log(S / X) + (R + 0.5f * V * V) * T, V * sqrtT);
 
     d2 = d1 - V * sqrtT;
 
@@ -75,7 +75,7 @@ ALPAKA_FN_ACC void BlackScholesBodyGPU(
     CNDD2 = cndGPU(acc, d2);
 
     //Calculate Call and Put simultaneously
-    expRT = __expf(- R * T);
+    expRT = cupla::exp(- R * T);
     CallResult = S * CNDD1 - X * expRT * CNDD2;
     PutResult  = X * expRT * (1.0f - CNDD2) - S * (1.0f - CNDD1);
 }

--- a/include/cupla/device_functions.hpp
+++ b/include/cupla/device_functions.hpp
@@ -25,3 +25,4 @@
 #include "cupla/device/Index.hpp"
 #include "cupla/device/Atomic.hpp"
 #include "cupla/device/SharedMemory.hpp"
+#include "cupla/math.hpp"

--- a/include/cupla/math.hpp
+++ b/include/cupla/math.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,11 @@
 
 #pragma once
 
-#include "cupla.hpp"
-
-#include "cupla/device_functions.hpp"
-
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+#include "cupla/math/Abs.hpp"
+#include "cupla/math/Comparison.hpp"
+#include "cupla/math/Exp.hpp"
+#include "cupla/math/Log.hpp"
+#include "cupla/math/Mod.hpp"
+#include "cupla/math/Root.hpp"
+#include "cupla/math/Round.hpp"
+#include "cupla/math/Trigo.hpp"

--- a/include/cupla/math/Abs.hpp
+++ b/include/cupla/math/Abs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,23 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/device_functions.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+    //! Computes the absolute value.
+    CUPLA_UNARY_MATH_FN( abs, alpaka::math::ConceptMathAbs, Abs )
+
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Common.hpp
+++ b/include/cupla/math/Common.hpp
@@ -1,0 +1,162 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include "cupla/types.hpp"
+
+#include <alpaka/core/Concepts.hpp>
+
+#include <type_traits>
+
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
+namespace detail
+{
+    /** Get the concept implementation of the current accelerator
+     *
+     * @tparam T_Concept alpaka concept
+     * @return implementation of the concept
+     */
+    ALPAKA_NO_HOST_ACC_WARNING
+    template< typename T_Concept >
+    ALPAKA_FN_HOST_ACC  auto getConcept()
+    {
+        using AccThreadSeqMathConcept = alpaka::concepts::ImplementationBase<
+            T_Concept,
+            AccThreadSeq
+        >;
+        using AccMathConcept = alpaka::concepts::ImplementationBase<
+            T_Concept,
+            Acc
+        >;
+        // cupla Acc and AccThreadSeq should use the same math concept implementation
+        static_assert(
+            std::is_same<
+                AccMathConcept,
+                AccThreadSeqMathConcept
+            >::value,
+            "The math concept implementation for the type 'Acc' and 'AccThreadSeq' must be equal"
+        );
+        return AccMathConcept{};
+    }
+} // namespace detail
+
+/* Using the free alpaka functions `alpaka::math::*` will result into `__host__ __device__`
+ * errors, therefore the alpaka math trait must be used.
+ */
+#define CUPLA_UNARY_MATH_FN(functionName, alpakaMathConcept, alpakaMathTrait)  \
+    /**                                                                        \
+     * @tparam T_Type argument type                                            \
+     * @param arg input argument                                               \
+     */                                                                        \
+    ALPAKA_NO_HOST_ACC_WARNING                                                 \
+    template< typename T_Type >                                                \
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE auto functionName(                          \
+        T_Type const & arg                                                     \
+    )                                                                          \
+    /* return type is required because nvcc can not detect the return type     \
+     * for device functions.                                                   \
+     */                                                                        \
+    ->  decltype(                                                              \
+        alpaka::math::traits::alpakaMathTrait<                                 \
+            alpaka::concepts::ImplementationBase<                              \
+                alpakaMathConcept,                                             \
+                Acc                                                            \
+            >,                                                                 \
+            T_Type                                                             \
+        >::functionName(                                                       \
+            detail::getConcept< alpakaMathConcept >(),                         \
+            arg                                                                \
+        )                                                                      \
+    )                                                                          \
+    {                                                                          \
+        return alpaka::math::traits::alpakaMathTrait<                          \
+            alpaka::concepts::ImplementationBase<                              \
+                alpakaMathConcept,                                             \
+                Acc                                                            \
+            >,                                                                 \
+            T_Type                                                             \
+        >::functionName(                                                       \
+            detail::getConcept< alpakaMathConcept >(),                         \
+            arg                                                                \
+        );                                                                     \
+    }
+
+/* Using the free alpaka functions `alpaka::math::*` will result into `__host__ __device__`
+ * errors, therefore the alpaka math trait must be used.
+ */
+#define CUPLA_BINARY_MATH_FN(functionName, alpakaMathConcept, alpakaMathTrait) \
+    /**                                                                        \
+     * @tparam T_Type argument type                                            \
+     * @param arg1 first input argument                                        \
+     * @param arg2 second input argument                                       \
+     */                                                                        \
+    template<                                                                  \
+        typename T_Type1,                                                      \
+        typename T_Type2                                                       \
+    >                                                                          \
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto functionName(                     \
+        T_Type1 const & arg1,                                                  \
+        T_Type2 const & arg2                                                   \
+    )                                                                          \
+    /* return type is required because nvcc can not detect the return type     \
+     * for device functions.                                                   \
+     */                                                                        \
+    ->  decltype(                                                              \
+        alpaka::math::traits::alpakaMathTrait<                                 \
+            alpaka::concepts::ImplementationBase<                              \
+                alpakaMathConcept,                                             \
+                Acc                                                            \
+            >,                                                                 \
+            T_Type1,                                                           \
+            T_Type2                                                            \
+        >::functionName(                                                       \
+            detail::getConcept< alpakaMathConcept >(),                         \
+            arg1,                                                              \
+            arg2                                                               \
+        )                                                                      \
+    )                                                                          \
+    {                                                                          \
+        return alpaka::math::traits::alpakaMathTrait<                          \
+            alpaka::concepts::ImplementationBase<                              \
+                alpakaMathConcept,                                             \
+                Acc                                                            \
+            >,                                                                 \
+            T_Type1,                                                           \
+            T_Type2                                                            \
+        >::functionName(                                                       \
+            detail::getConcept< alpakaMathConcept >(),                         \
+            arg1,                                                              \
+            arg2                                                               \
+        );                                                                     \
+    }
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Comparison.hpp
+++ b/include/cupla/math/Comparison.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,25 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/device_functions.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+    //! Calculates the smaller value of two arguments.
+    CUPLA_BINARY_MATH_FN( min, alpaka::math::ConceptMathMin, Min )
+
+    //! Calculates the larger value of two arguments.
+    CUPLA_BINARY_MATH_FN( max, alpaka::math::ConceptMathMax, Max )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Exp.hpp
+++ b/include/cupla/math/Exp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,22 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/device_functions.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+    //! Computes e (Euler's number, 2.7182818...) raised to the given power.
+    CUPLA_UNARY_MATH_FN( exp, alpaka::math::ConceptMathExp, Exp )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Log.hpp
+++ b/include/cupla/math/Log.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,24 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#pragma once
 
-#include "cupla/device_functions.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
+
+    //! Computes the natural (base e) logarithm.
+    CUPLA_UNARY_MATH_FN( log, alpaka::math::ConceptMathLog, Log )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Mod.hpp
+++ b/include/cupla/math/Mod.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,25 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/device_functions.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+    //! Computes the floating-point remainder of the division operation x/y.
+    CUPLA_BINARY_MATH_FN( fmod, alpaka::math::ConceptMathFmod, Fmod )
+
+    //! Computes the IEEE remainder of the floating point division operation x/y.
+    CUPLA_BINARY_MATH_FN( remainder, alpaka::math::ConceptMathRemainder, Remainder )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Root.hpp
+++ b/include/cupla/math/Root.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 Rene Widera
+/* Copyright 2020 Rene Widera
  *
  * This file is part of cupla.
  *
@@ -21,9 +21,28 @@
 
 #pragma once
 
-#include "cupla.hpp"
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
 
-#include "cupla/device_functions.hpp"
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
 
-#include "cupla/cudaToCupla/driverTypes.hpp"
-#include "cupla/cudaToCupla/runtime.hpp"
+    //! Computes the square root.
+    CUPLA_UNARY_MATH_FN( sqrt, alpaka::math::ConceptMathSqrt, Sqrt )
+
+    //! Computes the inverse square root.
+    CUPLA_UNARY_MATH_FN( rsqrt, alpaka::math::ConceptMathRsqrt, Rsqrt )
+
+    //! Computes the cubic root.
+    CUPLA_UNARY_MATH_FN( cbrt, alpaka::math::ConceptMathCbrt, Cbrt )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Round.hpp
+++ b/include/cupla/math/Round.hpp
@@ -1,0 +1,66 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
+
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
+
+    //! Computes the smallest integer value not less than arg.
+    CUPLA_UNARY_MATH_FN( ceil, alpaka::math::ConceptMathCeil, Ceil )
+
+    //! Computes the largest integer value not greater than arg.
+    CUPLA_UNARY_MATH_FN( floor, alpaka::math::ConceptMathFloor, Floor )
+
+    //! Computes the nearest integer not greater in magnitude than arg.
+    CUPLA_UNARY_MATH_FN( trunc, alpaka::math::ConceptMathTrunc, Trunc )
+
+    /** Computes the nearest integer value to arg (in floating-point format).
+     *
+     * Rounding halfway cases away from zero, regardless of the current rounding mode.
+     */
+    CUPLA_UNARY_MATH_FN( round, alpaka::math::ConceptMathRound, Round )
+
+    /** Computes the nearest integer value to arg (in integer format).
+     *
+     * Rounding halfway cases away from zero, regardless of the current rounding mode.
+     */
+    CUPLA_UNARY_MATH_FN( lround, alpaka::math::ConceptMathRound, Lround )
+
+    /** Computes the nearest integer value to arg (in integer format).
+     *
+     * Rounding halfway cases away from zero, regardless of the current rounding mode.
+     */
+    CUPLA_UNARY_MATH_FN( llround, alpaka::math::ConceptMathRound, Llround )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla

--- a/include/cupla/math/Trigo.hpp
+++ b/include/cupla/math/Trigo.hpp
@@ -1,0 +1,60 @@
+/* Copyright 2020 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include "cupla/math/Common.hpp"
+#include "cupla/types.hpp"
+
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+inline namespace device
+{
+inline namespace math
+{
+
+    //! Computes the sine (measured in radians).
+    CUPLA_UNARY_MATH_FN( sin, alpaka::math::ConceptMathSin, Sin )
+
+    //! Computes the cosine (measured in radians).
+    CUPLA_UNARY_MATH_FN( cos, alpaka::math::ConceptMathCos, Cos )
+
+    //! Computes the tangent (measured in radians).
+    CUPLA_UNARY_MATH_FN( tan, alpaka::math::ConceptMathTan, Tan )
+
+    //! Computes the principal value of the arc sine.
+    CUPLA_UNARY_MATH_FN( asin, alpaka::math::ConceptMathAsin, Asin )
+
+    //! Computes the principal value of the arc cosine.
+    CUPLA_UNARY_MATH_FN( acos, alpaka::math::ConceptMathAcos, Acos )
+
+    //! Computes the principal value of the arc tangent.
+    CUPLA_UNARY_MATH_FN( atan, alpaka::math::ConceptMathAtan, Atan )
+
+    //! Computes the arc tangent of y/x using the signs of arguments to determine the correct quadrant.
+    CUPLA_BINARY_MATH_FN( atan2, alpaka::math::ConceptMathAtan2, Atan2 )
+
+} // namespace math
+} // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla


### PR DESCRIPTION
- Expose alpaka math functions without accelerator parameter in the
signature.
- Use use cupla math functions for the example `BlackScholes`.

Please review only the last two commits, all other commits are from #160.

- [x] merge after #160 
