### PR TITLE
fix ambiguous namespace `device`

### DIFF
--- a/include/cupla/device/Atomic.hpp
+++ b/include/cupla/device/Atomic.hpp
@@ -29,6 +29,8 @@
 
 namespace cupla
 {
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 inline namespace device
 {
 
@@ -173,4 +175,5 @@ inline namespace device
          */
 
 } // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla

--- a/include/cupla/device/Index.hpp
+++ b/include/cupla/device/Index.hpp
@@ -28,6 +28,8 @@
 
 namespace cupla
 {
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 inline namespace device
 {
 
@@ -117,4 +119,5 @@ inline namespace device
     }
 
 } // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla

--- a/include/cupla/device/Synchronization.hpp
+++ b/include/cupla/device/Synchronization.hpp
@@ -27,6 +27,8 @@
 
 namespace cupla
 {
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 inline namespace device
 {
 
@@ -54,4 +56,5 @@ inline namespace device
     //!@}
 
 } // namespace device
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla


### PR DESCRIPTION
Move all device implementations into the inline namespace `CUPLA_ACCELERATOR_NAMESPACE`

This bug becomes visible in PIConGPU wenn using #162 and #160 together. Since math functions are template based a math function must be used to trigger the bug.