### PR TITLE
refactor math functions

### DIFF
--- a/example/CUDASamples/blackScholes/src/BlackScholes_gold.cpp
+++ b/example/CUDASamples/blackScholes/src/BlackScholes_gold.cpp
@@ -12,7 +12,7 @@
 
 
 #include <math.h>
-
+#include <cupla.hpp>
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -28,10 +28,10 @@ static double CND(double d)
     const double RSQRT2PI = 0.39894228040143267793994605993438;
 
     double
-    K = 1.0 / (1.0 + 0.2316419 * fabs(d));
+    K = 1.0 / (1.0 + 0.2316419 * cupla::abs(d));
 
     double
-    cnd = RSQRT2PI * exp(- 0.5 * d * d) *
+    cnd = RSQRT2PI * cupla::exp(- 0.5 * d * d) *
           (K * (A1 + K * (A2 + K * (A3 + K * (A4 + K * A5)))));
 
     if (d > 0)
@@ -56,8 +56,8 @@ static void BlackScholesBodyCPU(
 {
     double S = Sf, X = Xf, T = Tf, R = Rf, V = Vf;
 
-    double sqrtT = sqrt(T);
-    double    d1 = (log(S / X) + (R + 0.5 * V * V) * T) / (V * sqrtT);
+    double sqrtT = cupla::sqrt(T);
+    double    d1 = (cupla::log(S / X) + (R + 0.5 * V * V) * T) / (V * sqrtT);
     double    d2 = d1 - V * sqrtT;
     double CNDD1 = CND(d1);
     double CNDD2 = CND(d2);

--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -84,8 +84,8 @@
  * to avoid negative performance impact intrinsic function redefinitions
  * are disabled in CUDA
  */
-#if !defined(__CUDA_ARCH__)
-#define __fdividef(a,b) ((a)/(b))
-#define __expf(a) alpaka::math::exp(acc,a)
-#define __logf(a) alpaka::math::log(acc,a)
+#if CUPLA_DEVICE_COMPILE == 0
+#   define __fdividef(a,b) ((a)/(b))
+#   define __expf(a) cupla::math::exp(a)
+#   define __logf(a) cupla::math::log(a)
 #endif

--- a/include/cupla/defines.hpp
+++ b/include/cupla/defines.hpp
@@ -111,3 +111,17 @@
 #ifndef CUPLA_HEADER_ONLY_FUNC_SPEC
 #   define CUPLA_HEADER_ONLY_FUNC_SPEC
 #endif
+
+/*! device compile flag
+ *
+ * Enabled if the compiler processes currently a separate compile path for the device code
+ *
+ * @attention value is always 0 for alpaka CPU accelerators
+ *
+ * Value is 1 if device path is compiled else 0
+ */
+#if defined(__CUDA_ARCH__) || ( defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__== 1 && defined(__HIP__) )
+    #define CUPLA_DEVICE_COMPILE 1
+#else
+    #define CUPLA_DEVICE_COMPILE 0
+#endif


### PR DESCRIPTION
- change function attribute from `ALPAKA_FN_ACC` to `ALPAKA_FN_HOST_ACC`
- map host side math functions to alpaka stl math functions
- add precompiler define to handle device code path compilation e.g. with CUDA or HIP.

The previous implementation of math function was not working correctly in PIConGPU due to the function attributes. The older implementation also not allowed to write a functor which can be used on device and host. This is now fixed, if you call a cupla math function within the host compile path of the compiler it will always map function calls to the alpaka stl math implementations. 
Internally we discussed to implement this into PMacc cupla users should also be able to implement a functor which can be used on device and the host.