### PR TITLE
Second try: Extends GitLab CI scripts to run different compiler versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,40 +1,78 @@
+################################################################################
+# CUPLA_CXX                             : {g++, clang++}
+#   [g++]                               : {5, 6, 7, 8, 9} <list>
+#   [clang++]                           : {4.0, 5.0, 6.0, 7, 8, 9, 10} <list>
+# CUPLA_BOOST_VERSIONS                  : {1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0, 1.70.0, 1.71.0, 1.72.0, 1.73.0} <list>
+# CUPLA_BUILD_TYPE                      : {Debug, Release}
+# CUPLA_CMAKE_ARGS                      : <string>
 include:
   - local: '/script/compiler_base.yml'
-    
+
 cuda92:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2
   variables:
-    BOOST_VERSION: 1.73.0
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
   extends: .base_cuda
 
 cuda100:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0
   variables:
-    BOOST_VERSION: 1.73.0
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
   extends: .base_cuda
 
 cuda101:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1
   variables:
-    BOOST_VERSION: 1.73.0
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
   extends: .base_cuda
 
 cuda102:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2
   variables:
-    BOOST_VERSION: 1.73.0
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
   extends: .base_cuda
 
-gcc7:
+gcc1:
   variables:
-    CXX: g++
-    CC: gcc
-    BOOST_VERSION: 1.73.0
+    CUPLA_CXX: "g++-5 g++-6 g++-7 g++-8 g++-9"
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0"
   extends: .base_gcc
 
-clang7:
+gcc2:
   variables:
-    CXX: clang++-7
-    CC: clang-7
-    BOOST_VERSION: 1.73.0
+    CUPLA_CXX: "g++-5 g++-6 g++-7 g++-8 g++-9"
+    CUPLA_BOOST_VERSIONS: "1.68.0 1.69.0 1.70.0"
+  extends: .base_gcc
+
+gcc3:
+  variables:
+    CUPLA_CXX: "g++-5 g++-6 g++-7 g++-8 g++-9"
+    CUPLA_BOOST_VERSIONS: "1.71.0 1.72.0 1.73.0"
+  extends: .base_gcc
+
+clang:
+  variables:
+    CUPLA_CXX: "clang++-5.0 clang++-6.0 clang++-7 clang++-8 clang++-9 clang++-10"
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
   extends: .base_clang
+
+cudaClang92:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2Clang
+  variables:
+    CUPLA_CXX: "clang++-8 clang++-9 clang++-10"
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
+  extends: .base_cuda_clang
+
+cudaClang100:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0Clang
+  variables:
+    CUPLA_CXX: "clang++-8 clang++-9 clang++-10"
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
+  extends: .base_cuda_clang
+
+cudaClang101:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1Clang
+  variables:
+    CUPLA_CXX: "clang++-9 clang++-10"
+    CUPLA_BOOST_VERSIONS: "1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0 1.71.0 1.72.0 1.73.0"
+  extends: .base_cuda_clang

--- a/script/compiler_base.yml
+++ b/script/compiler_base.yml
@@ -1,15 +1,13 @@
-include:
-  - local: '/script/run_test.yml'
-
 .base_gcc:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:gcc
   variables:
     GIT_SUBMODULE_STRATEGY: normal
-    ALPAKA_ACCS: "-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
-                  -DALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=ON
-                  -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
-                  # -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON
-  extends: .test_job
+    ALPAKA_ACCS: "ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE
+                  ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE
+                  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE"
+                  # ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE
+  script:
+    - source script/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
@@ -18,11 +16,12 @@ include:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:clang
   variables:
     GIT_SUBMODULE_STRATEGY: normal
-    ALPAKA_ACCS: "-DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
-                  -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
+    ALPAKA_ACCS: "ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE
+                  ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE"
                   # -DALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=ON
                   # -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON
-  extends: .test_job
+  script:
+      - source script/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
@@ -30,13 +29,27 @@ include:
 .base_cuda:
   variables:
     GIT_SUBMODULE_STRATEGY: normal
-    CXX: g++
-    CC: gcc
-    ALPAKA_ACCS: "-DALPAKA_ACC_GPU_CUDA_ENABLE=ON"
+    CUPLA_CXX: g++
+    ALPAKA_ACCS: "ALPAKA_ACC_GPU_CUDA_ENABLE"
   before_script:
     - nvidia-smi
     - nvcc --version
-  extends: .test_job
+  script:
+      - source script/run_test.sh
+  tags:
+    - cuda
+    - intel
+
+.base_cuda_clang:
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+    ALPAKA_ACCS: "ALPAKA_ACC_GPU_CUDA_ENABLE"
+    CUPLA_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
+  before_script:
+    - nvidia-smi
+    - nvcc --version
+  script:
+      - source script/run_test.sh
   tags:
     - cuda
     - intel

--- a/script/run_test.sh
+++ b/script/run_test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# the default build type is Release
+# if neccesary, you can rerun the pipeline with another build type-> https://docs.gitlab.com/ee/ci/pipelines.html#manually-executing-pipelines
+# to change the build type, you must set the environment variable CUPLA_BUILD_TYPE
+
+if [[ ! -v CUPLA_BUILD_TYPE ]] ; then
+    CUPLA_BUILD_TYPE=Release ;
+fi
+
+###################################################
+# cmake config builder
+###################################################
+
+CUPLA_CONST_ARGS=""
+CUPLA_CONST_ARGS="${CUPLA_CONST_ARGS} -DCMAKE_BUILD_TYPE=${CUPLA_BUILD_TYPE}"
+CUPLA_CONST_ARGS="${CUPLA_CONST_ARGS} ${CUPLA_CMAKE_ARGS}"
+
+CMAKE_CONFIGS=()
+for CXX_VERSION in $CUPLA_CXX; do
+    for BOOST_VERSION in ${CUPLA_BOOST_VERSIONS}; do
+	for ACC in ${ALPAKA_ACCS}; do
+	    CMAKE_CONFIGS+=("${CUPLA_CONST_ARGS} -DCMAKE_CXX_COMPILER=${CXX_VERSION} -DBOOST_ROOT=/opt/boost/${BOOST_VERSION} -D${ACC}=ON")
+	done
+    done
+done
+
+###################################################
+# build an run tests
+###################################################
+
+# use one build directory for all build configurations
+mkdir build
+cd build
+
+export cupla_DIR=$CI_PROJECT_DIR
+
+# ALPAKA_ACCS contains the backends, which are used for each build
+# the backends are set in the sepcialized base jobs .base_gcc,.base_clang and.base_cuda
+for CONFIG in $(seq 0 $((${#CMAKE_CONFIGS[*]} - 1))); do
+    CMAKE_ARGS=${CMAKE_CONFIGS[$CONFIG]}
+    echo -e "\033[0;32m///////////////////////////////////////////////////"
+    echo "number of processor threads -> $(nproc)"
+    cmake --version | head -n 1
+    echo "CMAKE_ARGS -> ${CMAKE_ARGS}"
+    echo -e "/////////////////////////////////////////////////// \033[0m \n\n"
+
+    echo "###################################################"
+    echo "# Example Matrix Multiplication (adapted original)"
+    echo "###################################################"
+    echo "can not run with CPU_B_SEQ_T_SEQ due to missing elements layer in original SDK example"
+    echo "CPU_B_SEQ_T_OMP2/THREADS too many threads necessary (256)"
+    if [[ $CMAKE_ARGS =~ -*DALPAKA_ACC_GPU_CUDA_ENABLE=ON.* ]]; then
+        cmake $cupla_DIR/example/CUDASamples/matrixMul/ \
+	      $CMAKE_ARGS
+        make -j
+        time ./matrixMul -wA=64 -wB=64 -hA=64 -hB=64
+        rm -r * ;
+    fi
+
+    echo "###################################################"
+    echo "# Example Async API (adapted original)"
+    echo "###################################################"
+    echo "can not run with CPU_B_SEQ_T_SEQ due to missing elements layer in original SDK example"
+    echo "CPU_B_SEQ_T_OMP2/THREADS too many threads necessary (512)"
+    if [[ $CMAKE_ARGS =~ -*DALPAKA_ACC_GPU_CUDA_ENABLE=ON.* ]]; then
+        cmake $cupla_DIR/example/CUDASamples/asyncAPI/ \
+	      $CMAKE_ARGS
+        make -j
+        time ./asyncAPI
+        rm -r * ;
+    fi
+
+    echo "###################################################"
+    echo "# Example Async API (added elements layer)"
+    echo "###################################################"
+    cmake $cupla_DIR/example/CUDASamples/asyncAPI_tuned/ \
+	  $CMAKE_ARGS
+    make -j
+    time ./asyncAPI_tuned
+    rm -r *
+
+    echo "###################################################"
+    echo "Example vectorAdd (added elements layer)"
+    echo "###################################################"
+    cmake $cupla_DIR/example/CUDASamples/vectorAdd/ \
+	  $CMAKE_ARGS
+    make -j
+    time ./vectorAdd 100000
+    rm -r * ;
+done


### PR DESCRIPTION
Second try to melt the CI. The original PR was aborted because of some wrong merges before: #174  