### PR TITLE
config headers: not require cupla renaming headers

### DIFF
--- a/include/cupla/config/CpuOmp2Blocks.hpp
+++ b/include/cupla/config/CpuOmp2Blocks.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/CpuOmp2Threads.hpp
+++ b/include/cupla/config/CpuOmp2Threads.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/CpuOmp4.hpp
+++ b/include/cupla/config/CpuOmp4.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/CpuSerial.hpp
+++ b/include/cupla/config/CpuSerial.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/CpuTbbBlocks.hpp
+++ b/include/cupla/config/CpuTbbBlocks.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/CpuThreads.hpp
+++ b/include/cupla/config/CpuThreads.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/GpuCudaRt.hpp
+++ b/include/cupla/config/GpuCudaRt.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/include/cupla/config/GpuHipRt.hpp
+++ b/include/cupla/config/GpuHipRt.hpp
@@ -40,4 +40,4 @@
 #   include "cupla/../../src/stream.cpp"
 #endif
 
-#include "cuda_to_cupla.hpp"
+#include "cupla.hpp"

--- a/test/system/config/kernel.cpp
+++ b/test/system/config/kernel.cpp
@@ -35,6 +35,8 @@
 #   include <cupla/config/GpuHipRt.hpp>
 #endif
 
+#include "cuda_to_cupla.hpp"
+
 struct IncrementKernel
 {
     template<typename T_Acc>

--- a/test/system/config/main.cpp
+++ b/test/system/config/main.cpp
@@ -35,6 +35,8 @@
 #   include <cupla/config/GpuHipRt.hpp>
 #endif
 
+#include "cuda_to_cupla.hpp"
+
 extern void callIncrementKernel(int* pr_d);
 
 int main()


### PR DESCRIPTION
Currently the config headers enforce the usage of CUDA renaming headers.
Since #161 the user can use plain cupla or by explicit include `cuda_to_cupla.hpp` to be able to use `cuda*` function call.