### PR TITLE
Add support for Alpaka's OpenMP 5 and OpenACC backends

### DIFF
--- a/cuplaConfig.cmake
+++ b/cuplaConfig.cmake
@@ -105,7 +105,8 @@ OPTION(ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE "Enable the fibers CPU block thread 
 OPTION(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE "Enable the TBB CPU grid block back-end" OFF)
 OPTION(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE "Enable the OpenMP 2.0 CPU grid block accelerator" OFF)
 OPTION(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE "Enable the OpenMP 2.0 CPU block thread accelerator" OFF)
-OPTION(ALPAKA_ACC_CPU_BT_OMP4_ENABLE "Enable the OpenMP 4.0 CPU block and block thread accelerator" OFF)
+OPTION(ALPAKA_ACC_ANY_BT_OMP5_ENABLE "Enable the OpenMP 5 offloading block and block thread accelerator" OFF)
+OPTION(ALPAKA_ACC_ANY_BT_OACC_ENABLE "Enable the experimental OpenACC offloading block and block thread accelerator" OFF)
 OPTION(ALPAKA_ACC_GPU_CUDA_ENABLE "Enable the CUDA GPU accelerator" OFF)
 OPTION(ALPAKA_ACC_GPU_HIP_ENABLE "Enable the HIP back-end (all other back-ends must be disabled)" OFF)
 

--- a/include/cupla/config/AnyOacc.hpp
+++ b/include/cupla/config/AnyOacc.hpp
@@ -1,0 +1,43 @@
+/* Copyright 2020 Jeffrey Kelling
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/AnyOacc.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif
+
+#include "cupla.hpp"

--- a/include/cupla/config/AnyOmp5.hpp
+++ b/include/cupla/config/AnyOmp5.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/standalone/CpuOmp4>
+#include <alpaka/standalone/AnyOmp5.hpp>
 
 #ifndef CUPLA_HEADER_ONLY
 #   define CUPLA_HEADER_ONLY 1

--- a/include/cupla/defines.hpp
+++ b/include/cupla/defines.hpp
@@ -60,9 +60,14 @@
 #   define ALPAKA_ACC_GPU_HIP_ENABLED 1
 #endif
 
-#ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-#   undef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-#   define ALPAKA_ACC_CPU_BT_OMP4_ENABLED 1
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+#   undef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+#   define ALPAKA_ACC_ANY_BT_OMP5_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+#   undef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+#   define ALPAKA_ACC_ANY_BT_OACC_ENABLED 1
 #endif
 
 #define CUPLA_NUM_SELECTED_DEVICES (                                           \
@@ -73,7 +78,8 @@
         ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
         ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED +                                   \
         ALPAKA_ACC_GPU_HIP_ENABLED +                                           \
-        ALPAKA_ACC_CPU_BT_OMP4_ENABLED                                         \
+        ALPAKA_ACC_ANY_BT_OMP5_ENABLED +                                       \
+        ALPAKA_ACC_ANY_BT_OACC_ENABLED                                         \
 )
 
 
@@ -97,7 +103,8 @@
         ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
         ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
         ALPAKA_ACC_GPU_HIP_ENABLED +                                           \
-        ALPAKA_ACC_CPU_BT_OMP4_ENABLED                                         \
+        ALPAKA_ACC_ANY_BT_OMP5_ENABLED +                                       \
+        ALPAKA_ACC_ANY_BT_OACC_ENABLED                                         \
 )
 
 #if( CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES > 1 )

--- a/include/cupla/namespace.hpp
+++ b/include/cupla/namespace.hpp
@@ -54,8 +54,8 @@
 #           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
 #       endif
 
-#       ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp4_omp4_async
+#       ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp5_omp5_async
 #       endif
 
 #   endif // mixed accelerator usage
@@ -91,8 +91,8 @@
 #           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
 #       endif
 
-#       ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp4_omp4_sync
+#       ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp5_omp5_sync
 #       endif
 
 #   endif // mixed accelerator usage

--- a/include/cupla/types.hpp
+++ b/include/cupla/types.hpp
@@ -63,8 +63,7 @@ inline namespace CUPLA_ACCELERATOR_NAMESPACE
     defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED) ||                         \
     defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED) ||                            \
     defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED) ||                             \
-    defined(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED) ||                             \
-    defined(ALPAKA_ACC_CPU_BT_OMP4_ENABLED)
+    defined(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
 
     using AccDev = ::alpaka::DevCpu;
 #   if (CUPLA_STREAM_ASYNC_ENABLED == 1)
@@ -129,15 +128,33 @@ inline namespace CUPLA_ACCELERATOR_NAMESPACE
     #endif
 #endif
 
-#ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
-    using Acc = ::alpaka::AccCpuOmp4<
+#endif
+
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+    using AccDev = ::alpaka::DevOmp5;
+#   if (CUPLA_STREAM_ASYNC_ENABLED == 1)
+        using AccStream = ::alpaka::QueueOmp5NonBlocking;
+#   else
+        using AccStream = ::alpaka::QueueOmp5Blocking;
+#   endif
+    using Acc = ::alpaka::AccOmp5<
         KernelDim,
         IdxType
     >;
 #endif
 
+#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+    using AccDev = ::alpaka::DevOacc;
+#   if (CUPLA_STREAM_ASYNC_ENABLED == 1)
+        using AccStream = ::alpaka::QueueOaccNonBlocking;
+#   else
+        using AccStream = ::alpaka::QueueOaccBlocking;
+#   endif
+    using Acc = ::alpaka::AccOacc<
+        KernelDim,
+        IdxType
+    >;
 #endif
-
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     using AccDev = ::alpaka::DevCudaRt;


### PR DESCRIPTION
Add support for Alpaka 0.6.0's [OpenMP 5](https://github.com/alpaka-group/alpaka/pull/1126) and (experimental) [OpenACC](https://github.com/alpaka-group/alpaka/pull/1127) backends.