### PR TITLE
Fix the header of the README.md

### DIFF
--- a/.rodare.json
+++ b/.rodare.json
@@ -59,7 +59,7 @@
             "type":"Other"
         }
     ],
-    "title":"cupla - C++ User interface for the Platform independent Library Alpaka",
+    "title":"cupla - C++ User interface for the Platform Independent Library alpaka",
     "access_right":"open",
     "upload_type":"software",
     "license":"LGPL-3.0",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**cupla** - C++ User interface for the Platform independent Library Alpaka
+**cupla** - C++ User interface for the Platform Independent Library alpaka
 ==========================================================================
 
 [![Code Status dev](https://gitlab.com/hzdr/crp/cupla/badges/dev/pipeline.svg?key_text=dev)](https://gitlab.com/hzdr/crp/cupla/pipelines/dev/latest)


### PR DESCRIPTION
There was a weird capitalization.
Fix the name in rodare.json that is a copy of the header

Note this PR is for `0.3.0-rc1`, which will then be merged to `dev`.