### PR TITLE
Allow to include alpaka via add_subdirectory before cupla in an external project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,19 @@ addSubdirectoryExternal:
   tags:
     - x86_64
 
+# build external project and use cupla via cmake add_subdirectory()
+# alpaka was included in the project cmake before cupla
+addSubdirectoryThirdPartyAlpaka:
+  stage: compile-and-run
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-gcc:1.4
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+    CUPLA_BOOST_VERSION: 1.73.0
+  script:
+    - source script/integration/build_add_subdirectory_third_party_alpaka.sh
+  tags:
+    - x86_64
+
 # build external project and use cupla via cmake find_package()
 # cupla was installed with disabled examples
 findPackageWithoutExample:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,29 +61,33 @@ option(cupla_BUILD_EXAMPLES "Build examples" OFF)
 set(_CUPLA_MIN_ALPAKA_VERSION 0.7.0)
 set(_CUPLA_UNSUPPORTED_ALPAKA_VERSION 0.8.0)
 
-# the alpaka provider for the internal alpaka is only available,
-# if cupla is used via add_subdirectory in another project
-# or examples are build
-if(cupla_BUILD_EXAMPLES OR (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}))
-  set(cupla_ALPAKA_PROVIDER "internal" CACHE STRING "Select which alpaka is used")
-  set_property(CACHE cupla_ALPAKA_PROVIDER PROPERTY STRINGS "internal;external")
-  mark_as_advanced(cupla_ALPAKA_PROVIDER)
+# do not search for alpaka if it already exists
+# for example, a project that includes alpaka via add_subdirectory before including cupla via add_subdirectory
+if(NOT TARGET alpaka::alpaka)
+  # the alpaka provider for the internal alpaka is only available,
+  # if cupla is used via add_subdirectory in another project
+  # or examples are build
+  if(cupla_BUILD_EXAMPLES OR (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}))
+    set(cupla_ALPAKA_PROVIDER "internal" CACHE STRING "Select which alpaka is used")
+    set_property(CACHE cupla_ALPAKA_PROVIDER PROPERTY STRINGS "internal;external")
+    mark_as_advanced(cupla_ALPAKA_PROVIDER)
 
-  if(${cupla_ALPAKA_PROVIDER} STREQUAL "internal")
-    set(alpaka_BUILD_EXAMPLES OFF)
-    set(BUILD_TESTING OFF)
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/alpaka)
-  else()
-    find_package(alpaka ${_CUPLA_MIN_ALPAKA_VERSION} REQUIRED HINTS $ENV{ALPAKA_ROOT})
+    if(${cupla_ALPAKA_PROVIDER} STREQUAL "internal")
+      set(alpaka_BUILD_EXAMPLES OFF)
+      set(BUILD_TESTING OFF)
+      add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/alpaka)
+    else()
+      find_package(alpaka ${_CUPLA_MIN_ALPAKA_VERSION} REQUIRED HINTS $ENV{ALPAKA_ROOT})
 
-    if(alpaka_VERSION VERSION_GREATER_EQUAL _CUPLA_UNSUPPORTED_ALPAKA_VERSION)
+      if(alpaka_VERSION VERSION_GREATER_EQUAL _CUPLA_UNSUPPORTED_ALPAKA_VERSION)
         message(WARNING "Unsupported alpaka version ${alpaka_VERSION}. "
-                "Supported versions [${_CUPLA_MIN_ALPAKA_VERSION},${_CUPLA_UNSUPPORTED_ALPAKA_VERSION}).")
+          "Supported versions [${_CUPLA_MIN_ALPAKA_VERSION},${_CUPLA_UNSUPPORTED_ALPAKA_VERSION}).")
+      endif()
     endif()
-  endif()
 
-  if(NOT TARGET alpaka::alpaka)
-    message(FATAL_ERROR "Required cupla dependency alpaka could not be found!")
+    if(NOT TARGET alpaka::alpaka)
+      message(FATAL_ERROR "Required cupla dependency alpaka could not be found!")
+    endif()
   endif()
 endif()
 

--- a/script/integration/build_add_subdirectory_third_party_alpaka.sh
+++ b/script/integration/build_add_subdirectory_third_party_alpaka.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+CUPLA_ROOT=$(pwd)
+
+##########################
+# create external project
+##########################
+mkdir /tmp/external_project
+cd /tmp/external_project
+# copy source file and CMakeLists.txt to external project to simulate external project
+EXT_PROJECT_ROOT=$(pwd)
+cp ${CUPLA_ROOT}/example/CUDASamples/cuplaVectorAdd/src/vectorAdd.cpp ${EXT_PROJECT_ROOT}
+cp ${CUPLA_ROOT}/test/integration/cupla_add_subdirectory_thirdparty_alpaka.cmake ${EXT_PROJECT_ROOT}/CMakeLists.txt
+mv ${CUPLA_ROOT}/alpaka ${EXT_PROJECT_ROOT}
+cd ${EXT_PROJECT_ROOT}
+# link cupla for add_subdirectory()
+ln -s ${CUPLA_ROOT} .
+
+##########################
+# build external project
+##########################
+mkdir build install
+export LD_LIBRARY_PATH=${EXT_PROJECT_ROOT}/install/lib:${LD_LIBRARY_PATH}
+echo $LD_LIBRARY_PATH
+cd build
+cmake .. -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DBOOST_ROOT=/opt/boost/${CUPLA_BOOST_VERSION} -DCMAKE_INSTALL_PREFIX=../install -DBUILD_SHARED_LIBS=ON
+cmake --build .
+cmake --install .
+
+##########################
+# test build
+##########################
+cd ../install
+ls
+bin/cuplaVectorAdd

--- a/test/integration/cupla_add_subdirectory_thirdparty_alpaka.cmake
+++ b/test/integration/cupla_add_subdirectory_thirdparty_alpaka.cmake
@@ -1,0 +1,29 @@
+#
+# Copyright 2021 Simeon Ehrig
+#
+# This file is part of cupla.
+#
+# cupla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cupla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cupla.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+cmake_minimum_required(VERSION 3.18.0)
+project(cuplaVectorAdd)
+
+add_subdirectory(alpaka)
+add_subdirectory(cupla)
+
+cupla_add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/vectorAdd.cpp)
+
+install(TARGETS ${PROJECT_NAME})


### PR DESCRIPTION
With this PR, the following CMake is possible in a project, which uses cupla.

```cmake
cmake_minimum_required(VERSION 3.18.0)
project(test)

add_subdirectory(alpaka)
add_subdirectory(cupla)

cupla_add_executable(${PROJECT_NAME} main.cpp)
```