### PR TITLE
CI: change HIP CI configuration

### DIFF
--- a/script/compiler_base.yml
+++ b/script/compiler_base.yml
@@ -68,7 +68,6 @@
     - hipcc --version
   script:
     # use Vega 64 of the CI node
-    - export HIP_VISIBLE_DEVICES=2
     - source script/run_test.sh
   tags:
     - amd


### PR DESCRIPTION
The AMD CI node is hosting since 13.12.2021 only one GPU, therefore we do not need to select a device anymore.