### PR TITLE
remove master branch badge and links

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ cmake --build .
 cmake --install .
 ```
 
-To check your installation, you can activate the examples (see section [compiling an example](https://github.com/alpaka-group/cupla/blob/master/INSTALL.md#compile-an-example)) during the configuration of `cupla` and check whether it compiles. Activating the examples does not change anything in the installed `cupla` library.
+To check your installation, you can activate the examples (see section [compiling an example](https://github.com/alpaka-group/cupla/blob/dev/INSTALL.md#compile-an-example)) during the configuration of `cupla` and check whether it compiles. Activating the examples does not change anything in the installed `cupla` library.
 
 ```bash
 # use external alpka to verify your environment

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 **cupla** - C++ User interface for the Platform Independent Library alpaka
 ==========================================================================
 
-[![Code Status master](https://gitlab.com/hzdr/crp/cupla/badges/master/pipeline.svg?key_text=master)](https://gitlab.com/hzdr/crp/cupla/pipelines/master/latest)
 [![Code Status dev](https://gitlab.com/hzdr/crp/cupla/badges/dev/pipeline.svg?key_text=dev)](https://gitlab.com/hzdr/crp/cupla/pipelines/dev/latest)
 
 ![cupla Release](doc/logo/cupla_logo_320x210.png)

--- a/doc/ConfigurationHeader.md
+++ b/doc/ConfigurationHeader.md
@@ -24,7 +24,7 @@ Depending of the used accelerator you must link the library `pthread` and/or act
 Example
 =======
 
-To select an accelerator you must include the corresponding accelerator header from [`cupla/config/`](https://github.com/alpaka-group/cupla/tree/master/include/cupla/config)
+To select an accelerator you must include the corresponding accelerator header from [`cupla/config/`](https://github.com/alpaka-group/cupla/tree/dev/include/cupla/config)
 
 
 ```C++


### PR DESCRIPTION
The cupla master branch is now gone therefore all links should point to `dev`.