### PR TITLE
fix AMD CI run

### DIFF
--- a/script/compiler_base.yml
+++ b/script/compiler_base.yml
@@ -7,7 +7,7 @@
                   alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE"
                   # alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE
   script:
-    - source script/run_test.sh
+    - source ${CI_PROJECT_DIR}/script/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
@@ -21,7 +21,7 @@
                   # alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE=ON
                   # alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON
   script:
-      - source script/run_test.sh
+      - source ${CI_PROJECT_DIR}/script/run_test.sh
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
@@ -35,7 +35,7 @@
     - nvidia-smi
     - nvcc --version
   script:
-      - source script/run_test.sh
+      - source ${CI_PROJECT_DIR}/script/run_test.sh
   tags:
     - cuda
     - intel
@@ -51,7 +51,7 @@
     - nvidia-smi
     - nvcc --version
   script:
-      - source script/run_test.sh
+      - source ${CI_PROJECT_DIR}/script/run_test.sh
   tags:
     - cuda
     - intel
@@ -61,13 +61,12 @@
     GIT_SUBMODULE_STRATEGY: normal
     CUPLA_CXX: "hipcc"
     ALPAKA_ACCS: "alpaka_ACC_GPU_HIP_ENABLE"
-    # architecture of the Vega 64
-    CUPLA_CMAKE_ARGS: "-DGPU_TARGETS=gfx900"
   before_script:
+    - ${CI_PROJECT_DIR}/script/install_hip.sh
     - rocm-smi
     - hipcc --version
   script:
-    - source script/run_test.sh
+    - source ${CI_PROJECT_DIR}/script/run_test.sh
   tags:
     - amd
     - rocm

--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if ! [ -z ${CI_GPUS+x} ] && [ -n "$CI_GPUS" ] ; then
+    # select randomly a device if multiple exists
+    # CI_GPUS is provided by the gitlab CI runner
+    SELECTED_DEVICE_ID=$((RANDOM%CI_GPUS))
+    export HIP_VISIBLE_DEVICES=$SELECTED_DEVICE_ID
+    export CUDA_VISIBLE_DEVICES=$SELECTED_DEVICE_ID
+    echo "selected device '$SELECTED_DEVICE_ID' of '$CI_GPUS'"
+else
+    echo "No GPU device selected because environment variable CI_GPUS is not set."
+fi
+
+if [ -z ${CI_GPU_ARCH+x} ] ; then
+    # In case the runner is not providing a GPU architecture e.g. a CPU runner set the architecture
+    # to Radeon VII or MI50/60.
+    export GPU_TARGETS="gfx906"
+fi


### PR DESCRIPTION
The AMD CI configuration changed an dtherefore an update is required. The architecture for HIP is now provided via a CI environment variable. The current CI node has two GPUs, we perform a random load balancing between both GPUs.